### PR TITLE
Added `encoding` option to allow for non-B64 encoding

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ if(typeof Object.isset != 'function'){
 module.exports = function(options) {
 	options = options || {};
 	options.style = options.style || {};
+	options.encoding = options.encoding || 'base64';
 	options.className = options.className || '.icon.%s';
 	options.raw = options.raw || false;
 

--- a/svg.js
+++ b/svg.js
@@ -33,7 +33,7 @@ module.exports = {
 				? options.className(this.genName(file))
 				: _.sprintf(options.className, this.genName(file))
 			) + ' {\n' + 
-			'  background-image: url(\'data:image/svg+xml;base64,' + new Buffer(content).toString('base64') + '\');\n' +
+			'  background-image: url(\'data:image/svg+xml;' + options.encoding + ',' + new Buffer(content).toString(options.encoding) + '\');\n' +
 			'}\n'
 		);
 


### PR DESCRIPTION
If the output of this plugin goes through something like LESS, skipping base 64 encoding allows for passing preprocessor variables to the inlined SVGs.